### PR TITLE
✨ Feat: 공통 컴포넌트 Pagination 설계

### DIFF
--- a/src/components/layout/footer/footer.tsx
+++ b/src/components/layout/footer/footer.tsx
@@ -11,10 +11,10 @@ const Footer = () => {
             ©codeit - 2023
           </div>
           <div className='order-1 flex gap-[30px] font-normal text-gray-500'>
-            <Link href={'/'} className='text-body-s hover:text-gray-300 tablet:text-body-m'>
+            <Link href={'/'} className='text-body-s hover:text-gray-700 tablet:text-body-m'>
               Privacy Policy
             </Link>
-            <Link href={'/'} className='text-body-s hover:text-gray-300 tablet:text-body-m'>
+            <Link href={'/'} className='text-body-s hover:text-gray-700 tablet:text-body-m'>
               FAQ
             </Link>
           </div>

--- a/src/components/layout/footer/index.ts
+++ b/src/components/layout/footer/index.ts
@@ -1,0 +1,1 @@
+export { default as Footer } from './footer';

--- a/src/components/layout/frame/index.ts
+++ b/src/components/layout/frame/index.ts
@@ -1,0 +1,1 @@
+export { default as Frame } from './frame';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,2 +1,4 @@
 export { Container, Wrapper } from './container';
+export { Footer } from './footer';
+export { Frame } from './frame';
 export { Header } from './header';

--- a/src/components/ui/pagination/index.ts
+++ b/src/components/ui/pagination/index.ts
@@ -1,0 +1,1 @@
+export { default as Pagination } from './pagination';

--- a/src/components/ui/pagination/pagination.tsx
+++ b/src/components/ui/pagination/pagination.tsx
@@ -1,47 +1,50 @@
 import { Icon } from '@/components/ui';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const PAGE_GROUP_SIZE = 7;
-const ITEMS_PER_PAGE = 5;
 
 interface PaginationProps {
   totalItems: number;
+  currentPage: number;
+  itemsPerPage: number;
+  onPageChange: (page: number) => void;
 }
 // totalItems 는 API 통신 시 Response 로 받는 """count""" 부모로부터 넘겨주기!
 
-const Pagination = ({ totalItems }: PaginationProps) => {
-  const [currentPage, setCurrentPage] = useState(totalItems > 0 ? 1 : 0);
-  // [currentPage, setCurrentPage] 는 부모 페이지에서 받아올 데이터 내용
-  //  - 그래야 페이지 바뀔 때 부모 페이지에 state 영향 줘서 리렌더링해서 화면 다시 보여줌
-  //  - 이후 페이지 작업 시 위의 state 선언은 부모페이지에서 하고 값들 props 로 받기
+const Pagination = ({ totalItems, currentPage, itemsPerPage, onPageChange }: PaginationProps) => {
   const [pageGroup, setPageGroup] = useState(0);
 
-  const totlaPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
-  if (totlaPages === 0) return null;
+  const totalPages = totalItems ? Math.ceil(totalItems / itemsPerPage) : 0;
+
+  useEffect(() => {
+    const newGroup = Math.floor((currentPage - 1) / PAGE_GROUP_SIZE);
+    setPageGroup(newGroup);
+  }, [currentPage]);
+
+  if (totalPages < 1) return null;
+
   const startPage = pageGroup * PAGE_GROUP_SIZE + 1;
-  const endPage = Math.min(startPage + PAGE_GROUP_SIZE - 1, totlaPages);
+  const endPage = Math.min(startPage + PAGE_GROUP_SIZE - 1, totalPages);
   const pageNumbers = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
   const isPrevDisabled = pageGroup === 0;
-  const isNextDisabled = (pageGroup + 1) * PAGE_GROUP_SIZE >= totlaPages;
+  const isNextDisabled = (pageGroup + 1) * PAGE_GROUP_SIZE >= totalPages;
 
   return (
     <>
       <div className='flex h-14 items-center justify-center bg-white tablet:h-16'>
         <div className='flex h-8 items-center justify-center gap-[2px] px-3 py-2 tablet:h-10'>
-          <Icon
-            className={`h-5 w-5 ${isPrevDisabled ? 'bg-gray-400' : 'cursor-pointer'}`}
-            onClick={() => {
-              if (!isPrevDisabled) {
-                setPageGroup(prev => Math.max(prev - 1, 0));
-              }
-            }}
-            iconName='chevronLeft'
-            ariaLabel='이전'
-          />
+          <button className='flex items-center justify-center'>
+            <Icon
+              className={`h-5 w-5 ${isPrevDisabled ? 'cursor-default bg-gray-400' : 'cursor-pointer'}`}
+              onClick={() => !isPrevDisabled && setPageGroup(prev => Math.max(prev - 1, 0))}
+              iconName='chevronLeft'
+              ariaLabel='이전'
+            />
+          </button>
           {pageNumbers.map(page => (
             <button
               key={page}
-              onClick={() => setCurrentPage(page)}
+              onClick={() => onPageChange(page)}
               className={
                 page === currentPage
                   ? 'h-8 w-8 rounded bg-red-300 text-caption text-white tablet:text-body-s'
@@ -51,16 +54,17 @@ const Pagination = ({ totalItems }: PaginationProps) => {
               {page}
             </button>
           ))}
-          <Icon
-            className={`h-5 w-5 ${isNextDisabled ? 'bg-gray-400' : 'cursor-pointer'}`}
-            onClick={() => {
-              if (!isNextDisabled) {
-                setPageGroup(prev => ((prev + 1) * PAGE_GROUP_SIZE < totlaPages ? prev + 1 : prev));
+          <button className='flex items-center justify-center'>
+            <Icon
+              className={`h-5 w-5 ${isNextDisabled ? 'cursor-default bg-gray-400' : 'cursor-pointer'}`}
+              onClick={() =>
+                !isNextDisabled &&
+                setPageGroup(prev => ((prev + 1) * PAGE_GROUP_SIZE < totalPages ? prev + 1 : prev))
               }
-            }}
-            iconName='chevronRight'
-            ariaLabel='이후'
-          />
+              iconName='chevronRight'
+              ariaLabel='이후'
+            />
+          </button>
         </div>
       </div>
     </>

--- a/src/components/ui/pagination/pagination.tsx
+++ b/src/components/ui/pagination/pagination.tsx
@@ -1,0 +1,70 @@
+import { Icon } from '@/components/ui';
+import { useState } from 'react';
+
+const PAGE_GROUP_SIZE = 7;
+const ITEMS_PER_PAGE = 5;
+
+interface PaginationProps {
+  totalItems: number;
+}
+// totalItems 는 API 통신 시 Response 로 받는 """count""" 부모로부터 넘겨주기!
+
+const Pagination = ({ totalItems }: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(totalItems > 0 ? 1 : 0);
+  // [currentPage, setCurrentPage] 는 부모 페이지에서 받아올 데이터 내용
+  //  - 그래야 페이지 바뀔 때 부모 페이지에 state 영향 줘서 리렌더링해서 화면 다시 보여줌
+  //  - 이후 페이지 작업 시 위의 state 선언은 부모페이지에서 하고 값들 props 로 받기
+  const [pageGroup, setPageGroup] = useState(0);
+
+  const totlaPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+  if (totlaPages === 0) return null;
+  const startPage = pageGroup * PAGE_GROUP_SIZE + 1;
+  const endPage = Math.min(startPage + PAGE_GROUP_SIZE - 1, totlaPages);
+  const pageNumbers = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
+  const isPrevDisabled = pageGroup === 0;
+  const isNextDisabled = (pageGroup + 1) * PAGE_GROUP_SIZE >= totlaPages;
+
+  return (
+    <>
+      <div className='flex h-14 items-center justify-center bg-white tablet:h-16'>
+        <div className='flex h-8 items-center justify-center gap-[2px] px-3 py-2 tablet:h-10'>
+          <Icon
+            className={`h-5 w-5 ${isPrevDisabled ? 'bg-gray-400' : 'cursor-pointer'}`}
+            onClick={() => {
+              if (!isPrevDisabled) {
+                setPageGroup(prev => Math.max(prev - 1, 0));
+              }
+            }}
+            iconName='chevronLeft'
+            ariaLabel='이전'
+          />
+          {pageNumbers.map(page => (
+            <button
+              key={page}
+              onClick={() => setCurrentPage(page)}
+              className={
+                page === currentPage
+                  ? 'h-8 w-8 rounded bg-red-300 text-caption text-white tablet:text-body-s'
+                  : 'h-8 w-8 text-caption tablet:text-body-s'
+              }
+            >
+              {page}
+            </button>
+          ))}
+          <Icon
+            className={`h-5 w-5 ${isNextDisabled ? 'bg-gray-400' : 'cursor-pointer'}`}
+            onClick={() => {
+              if (!isNextDisabled) {
+                setPageGroup(prev => ((prev + 1) * PAGE_GROUP_SIZE < totlaPages ? prev + 1 : prev));
+              }
+            }}
+            iconName='chevronRight'
+            ariaLabel='이후'
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Pagination;

--- a/src/context/appProvider.tsx
+++ b/src/context/appProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import AuthProvider from './authProvider';
-import ToastProvider from './toastContext/toastContext';
+import { ToastProvider } from './toastContext';
 
 const AppProvider = ({ children }: { children: ReactNode }) => {
   return (

--- a/src/context/toastContext/index.ts
+++ b/src/context/toastContext/index.ts
@@ -1,0 +1,1 @@
+export { default as ToastProvider } from './toastContext';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import { Header, Wrapper } from '@/components/layout';
-import Footer from '@/components/layout/footer/footer';
+import { Footer, Header, Wrapper } from '@/components/layout';
+
 import AppProvider from '@/context/appProvider';
 
 import '@/styles/fonts.css';


### PR DESCRIPTION
공통 컴포넌트 Pagination 설계

## 📝 작업 개요 (필수)

받아오는 데이터 양에 따라 나누어지는 페이지이동 기능인 Pagination 구현.

피그마 시안에서 전체 페이지들 보니, 페이지 버튼은 7개까지 보여지고, 한 페이지에서 보여지는 데이터 수가 5개로 다 정해져있어서
해당 두 내용은 함수 밖 상수로 설정하여 작업했습니다.
혹시나 페이지버튼 개수나 받아오는 데이터양을 피그마 시안과 다르게 바꾸고싶다 하시면,
부모 컴포넌트에서 props 로 내려주고 Pagination 에서 받아서 적용시킬 수 있도록 추후 수정 해드릴 수 있습니다. 

첫 페이지에서는 '이전 버튼' , 마지막 페이지에서는 '이후 버튼' 클릭 못하게 disabled 로 막아두었습니다.


추가적으로, Footer 에서 hover 됐을 때 어두운 컬러로 수정하였습니다.

## ✨ 작업 내용 (필수)

- [x] 기능 구현
- [ ] 버그 수정
- [x] 스타일/UI 변경
- [ ] 리팩토링
- [ ] 최적화/성능개선
- [ ] 문서 업데이트
- [ ] 기타 변경사항

## 📸 스크린샷
## 🧐 해결해야 하는 문제
## 🤔 리뷰어 확인 필요 사항
## 🔗 관련 이슈
### 🛠️ 후속 작업

<!-- 이 PR 이후 필요한 추가 작업 -->

- [ ] **중요**
이후 페이지 작업이 진행되고 데이터를 받아오기 시작하면
부모 컴포넌트(Pagination 을 사용하는 페이지) 에서 API 통해 받아오는 데이터를 state 로 관리하게 될테니 해당 state 값들을
Pagination(자식 컴포넌트) props 로 내려주고 사용해야해서 추후 코드 수정이 있을 예정입니다.

### ✅ 체크리스트 (필수)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
- [x] ESLint 검사 통과
- [x] Prettier 포맷팅 적용
- [x] TypeScript 에러 없음
- [x] 빌드 에러 없음
