### PR TITLE
🐛 fix:  cardImage 컴포넌트 src 버그 수정

### DIFF
--- a/src/components/ui/card/cardImage.tsx
+++ b/src/components/ui/card/cardImage.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils/cn';
 import { type CardVariant } from '@/types/notice';
 import Image from 'next/image';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { cardLayout } from './card.styles';
 
 interface CardImageProps {
@@ -13,8 +13,12 @@ interface CardImageProps {
 }
 const FALLBACK_SRC = '/fallback.png';
 const CardImage = ({ variant, src, alt, className, children }: CardImageProps) => {
-  const image = src ?? FALLBACK_SRC;
-  const [imgSrc, setImgSrc] = useState(image);
+  const [imgSrc, setImgSrc] = useState(src ?? FALLBACK_SRC);
+
+  // src가 비동기로 들어오거나 변경될 때 state를 동기화
+  useEffect(() => {
+    setImgSrc(src ?? FALLBACK_SRC);
+  }, [src]);
 
   const handleError = () => {
     setImgSrc(FALLBACK_SRC);


### PR DESCRIPTION
## 📝 작업 개요 (필수)

<!-- 이 PR이 어떤 기능/수정/리팩토링을 하는지 간단히 요약 -->
cardImage 컴포넌트 src 버그 수정
state 초기값은 첫 렌더링에서만 적용되어 데이터가 비동기로 들어오면 fallback으로 초기화 되기 때문에 
이미지가 제대로 보이지 않는 현상이 발생했고, useEffect로 변경되면 다시 초기화 하게 변경되었습니다 


## ✨ 작업 내용 (필수)

- [ ] 기능 구현
- [x] 버그 수정
- [ ] 스타일/UI 변경
- [ ] 리팩토링
- [ ] 최적화/성능개선
- [ ] 문서 업데이트
- [ ] 기타 변경사항

## 📸 스크린샷

<!-- UI 변경 사항이 있다면 스크린샷 첨부 -->

## 🧐 해결해야 하는 문제

<!-- 개발하면서 어려움을 겪거나 고민이 필요한 부분 -->

## 🤔 리뷰어 확인 필요 사항

<!-- 리뷰어가 집중해서 봐줬으면 하는 부분 -->

## 🔗 관련 이슈

<!-- 관련된 이슈가 있다면 링크 -->

- Closes #이슈 번호
- Related to #이슈 번호

### 🛠️ 후속 작업

<!-- 이 PR 이후 필요한 추가 작업 -->

- [ ]
- [ ]

### ✅ 체크리스트 (필수)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
- [x] ESLint 검사 통과
- [x] Prettier 포맷팅 적용
- [x] TypeScript 에러 없음
- [x] 빌드 에러 없음
